### PR TITLE
Added option to disable flavor text message.

### DIFF
--- a/doc/nvim-unception.txt
+++ b/doc/nvim-unception.txt
@@ -46,6 +46,12 @@ SETTINGS                                               *nvim-unception-settings*
     in a new tab rather than placing them in the window that has focus.
 
 
+*g:unception_enable_flavor_text*                         bool (default=true)
+
+        When true, causes unception to echo a message whenever it is
+    triggered.
+
+
 *g:unception_disable*                                    bool (default=false)
 
         When true, disables nvim-unception.

--- a/lua/init_default_settings_vars.lua
+++ b/lua/init_default_settings_vars.lua
@@ -10,3 +10,7 @@ if (vim.g.unception_disable == nil) then
     vim.g.unception_disable = false
 end
 
+if (vim.g.unception_enable_flavor_text == nil) then
+    vim.g.unception_enable_flavor_text = true
+end
+

--- a/lua/unception.lua
+++ b/lua/unception.lua
@@ -75,8 +75,10 @@ local function build_command(arg_str, number_of_args, server_address)
     -- remove command from history and enter it
     cmd_to_execute = cmd_to_execute.."call histdel(':', -1)<CR>"
 
-    -- flavor text :)
-    cmd_to_execute = cmd_to_execute..":echo 'Unception prevented inception!' | call histdel(':', -1)<CR>"
+    if (vim.g.unception_enable_flavor_text) then
+        -- flavor text :)
+        cmd_to_execute = cmd_to_execute..":echo 'Unception prevented inception!' | call histdel(':', -1)<CR>"
+    end
 
     -- end command to be run by server
     cmd_to_execute = cmd_to_execute.."\""


### PR DESCRIPTION
Adds boolean `g:unception_enable_flavor_text` option to enable/disable flavor text message that's echoed whenever unception is triggered.