### PR TITLE
Git commit message buffers now appear in window that was used to launch them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ until the host quits the buffer being edited. This can be done by setting your
 git `core.editor` to pass the `g:unception_block_while_host_edits=1` argument
 (like
 [this](https://github.com/samjwill/dotfiles/blob/ba56af2ff49cd23ac19fcffe7840a78c58a89c9b/.gitconfig#L5)).
-Note that the terminal will be blocked until the built-in `QuitPre` event is triggered for the commit buffer.
+Note that the terminal will be blocked and its buffer will be hidden until Neovim's `QuitPre` event is triggered for the commit buffer, after which, the terminal buffer will be restored to its original location.
 
 Here's an example workflow with this flag set:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ until the host quits the buffer being edited. This can be done by setting your
 git `core.editor` to pass the `g:unception_block_while_host_edits=1` argument
 (like
 [this](https://github.com/samjwill/dotfiles/blob/ba56af2ff49cd23ac19fcffe7840a78c58a89c9b/.gitconfig#L5)).
-Note that the terminal will be blocked until the commit buffer is unloaded.
+Note that the terminal will be blocked until the built-in `QuitPre` event is triggered for the commit buffer.
 
 Here's an example workflow with this flag set:
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,16 @@ https://user-images.githubusercontent.com/25990267/170632310-8bbee2fa-672b-4385-
 There are a few options for using Neovim as your editor for git from within
 Neovim itself.
 
-The first option is to make git defer editing to the host session, and block until the host unloads the
-buffer being edited. This can be done by setting your git `core.editor` to pass
-the `g:unception_block_while_host_edits=1` argument (like
+The first option is to make git defer editing to the host session, and block
+until the host quits the buffer being edited. This can be done by setting your
+git `core.editor` to pass the `g:unception_block_while_host_edits=1` argument
+(like
 [this](https://github.com/samjwill/dotfiles/blob/ba56af2ff49cd23ac19fcffe7840a78c58a89c9b/.gitconfig#L5)).
 Note that the terminal will be blocked until the commit buffer is unloaded.
 
 Here's an example workflow with this flag set:
 
 https://user-images.githubusercontent.com/25990267/199399213-a0b72114-99b4-4b4b-9a14-8d7a7fc0bb3e.mp4
-
-Note that if Neovim's `'hidden'` option is set, the buffer will not
-be unloaded upon running `:wq`. Instead `:bdelete` will need to be
-called on the git commit message buffer to trigger the `BufUnload` event
-and unblock the shell.
 
 Alternatively, if you would like to be able to edit using Neovim directly
 inside of a nested session, you can disable unception altogether by setting

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note that the terminal will be blocked until the commit buffer is unloaded.
 
 Here's an example workflow with this flag set:
 
-https://user-images.githubusercontent.com/25990267/199399213-a0b72114-99b4-4b4b-9a14-8d7a7fc0bb3e.mp4
+https://user-images.githubusercontent.com/25990267/208282262-594b5693-8166-414b-9695-63fc02d3c25f.mp4
 
 Alternatively, if you would like to be able to edit using Neovim directly
 inside of a nested session, you can disable unception altogether by setting

--- a/doc/nvim-unception.txt
+++ b/doc/nvim-unception.txt
@@ -68,9 +68,15 @@ SETTINGS                                               *nvim-unception-settings*
 
         When true, if unception detects that Neovim has been launched in a
     nested terminal session, the file passed as an argument will be opened in
-    the host session, and the terminal will be blocked until the file has been
-    |BufUnload|ed. Note that only a single, filepath argument may be passed when
-    this is enabled.
+    the host session, and the terminal will be blocked until |QuitPre| is
+    triggered on the buffer. Note that only a single, filepath argument may be
+    passed when this is enabled.
+
+        If |g:unception_open_buffer_in_new_tab| is true, the new buffer will
+    be opened in a new tab rather than in the current window. If false, the
+    new buffer will be opened in the current window, making the buffer under
+    the cursor hidden, and restoring its visibility to the current window when
+    |QuitPre| is triggered.
 
         This can be useful for command-line tools that are expected to launch
     an editor, such as git. By setting the core editor to:

--- a/lua/init_default_settings_vars.lua
+++ b/lua/init_default_settings_vars.lua
@@ -18,10 +18,8 @@ if (vim.g.unception_block_while_host_edits == nil) then
     vim.g.unception_block_while_host_edits = false
 end
 
--- Can't allow buffer holding terminal to be deleted. Also don't want the
--- terminal buffer to get hidden, so open the buffer being edited in a new tab.
+-- Can't allow buffer holding terminal to be deleted.
 if (vim.g.unception_block_while_host_edits) then
-    vim.g.unception_open_buffer_in_new_tab = false
     vim.g.unception_delete_replaced_buffer = false
 end
 

--- a/lua/init_default_settings_vars.lua
+++ b/lua/init_default_settings_vars.lua
@@ -21,7 +21,7 @@ end
 -- Can't allow buffer holding terminal to be deleted. Also don't want the
 -- terminal buffer to get hidden, so open the buffer being edited in a new tab.
 if (vim.g.unception_block_while_host_edits) then
-    vim.g.unception_open_buffer_in_new_tab = true
+    vim.g.unception_open_buffer_in_new_tab = false
     vim.g.unception_delete_replaced_buffer = false
 end
 

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -40,11 +40,10 @@ function unception_handle_quitpre(quitpre_buffer_filepath)
 
     if (quitpre_buffer_filepath == filepath_to_check) then
         -- If this buffer replaced the blocked terminal buffer, we should restore it to the same window.
-        if (blocked_terminal_buffer_id ~= nil) then
-            -- Use pcall so that in the case where if the blocked buffer got deleted elsewhere, we won't prevent quitting the buffer.
-            pcall(vim.cmd, "split") -- Open a new window and switch focus to it.
-            pcall(vim.cmd, "buffer " .. blocked_terminal_buffer_id) -- Set the buffer for that window to the buffer that was replaced.
-            pcall(vim.cmd, "wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
+        if (blocked_terminal_buffer_id ~= nil and vim.fn.bufexists(blocked_terminal_buffer_id) == 1) then
+            vim.cmd("split") -- Open a new window and switch focus to it.
+            vim.cmd("buffer " .. blocked_terminal_buffer_id) -- Set the buffer for that window to the buffer that was replaced.
+            vim.cmd("wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
         end
 
         unblock_client_and_reset_state()

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -12,7 +12,7 @@ function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
     if (unloaded_buffer_filepath == filepath_to_check) then
         local win_id = vim.fn.win_getid()
         vim.cmd("split")
-        vim.cmd(win_id .. "-" .. win_id .. "windo buffer " id_of_replaced_buffer)
+        vim.cmd(win_id .. "-" .. win_id .. "windo buffer " .. id_of_replaced_buffer)
 
         vim.api.nvim_del_autocmd(unception_bufunload_autocmd_id)
         vim.fn.rpcnotify(response_sock, "nvim_exec_lua", "vim.cmd('quit')", {})
@@ -23,7 +23,7 @@ end
 function _G.unception_notify_when_done_editing(pipe_to_respond_on, filepath)
     filepath_to_check = filepath
     response_sock = vim.fn.sockconnect("pipe", pipe_to_respond_on, {rpc = true})
-    unception_bufunload_autocmd_id = vim.api.nvim_create_autocmd("BufUnload",{ command = "lua unception_handle_unloaded_buffer(vim.fn.expand('<afile>:p'))"})
+    unception_bufunload_autocmd_id = vim.api.nvim_create_autocmd("QuitPre",{ command = "lua unception_handle_unloaded_buffer(vim.fn.expand('<afile>:p'))"})
 end
 
 function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, delete_replaced_buffer, enable_flavor_text)

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -4,23 +4,25 @@ local response_sock = nil
 local unception_quitpre_autocmd_id = nil
 local unception_bufunload_autocmd_id = nil
 local filepath_to_check = nil
-local id_of_replaced_buffer = nil
+local blocked_terminal_buffer_id = nil
+local last_replaced_buffer_id = nil
 
 function unblock_client_and_reset_state()
-    -- Remove the autocmds we made
+    -- Remove the autocmds we made.
     vim.api.nvim_del_autocmd(unception_quitpre_autocmd_id)
     vim.api.nvim_del_autocmd(unception_bufunload_autocmd_id)
 
-    -- Unblock client by killing editor session.
+    -- Unblock client by killing its editor session.
     vim.fn.rpcnotify(response_sock, "nvim_exec_lua", "vim.cmd('quit')", {})
     vim.fn.chanclose(response_sock)
 
-    -- Reset state-sensitive variables
+    -- Reset state-sensitive variables.
     response_sock = nil
     unception_quitpre_autocmd_id = nil
     unception_bufunload_autocmd_id = nil
     filepath_to_check = nil
-    id_of_replaced_buffer = nil
+    blocked_terminal_buffer_id = nil
+    last_replaced_buffer_id = nil
 end
 
 function unception_handle_bufunload(unloaded_buffer_filepath)
@@ -38,9 +40,9 @@ function unception_handle_quitpre(quitpre_buffer_filepath)
 
     if (quitpre_buffer_filepath == filepath_to_check) then
         -- If there was a replaced buffer, we should restore it to the same window.
-        if (id_of_replaced_buffer ~= nil) then
-            vim.cmd("split") -- Open a new window and switch focus to it
-            vim.cmd("buffer " .. id_of_replaced_buffer) -- Set the buffer for that window to the buffer that was replaced.
+        if (blocked_terminal_buffer_id ~= nil) then
+            vim.cmd("split") -- Open a new window and switch focus to it.
+            vim.cmd("buffer " .. blocked_terminal_buffer_id) -- Set the buffer for that window to the buffer that was replaced.
             vim.cmd("wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
         end
 
@@ -50,10 +52,11 @@ end
 
 function _G.unception_notify_when_done_editing(pipe_to_respond_on, filepath)
     filepath_to_check = filepath
+    blocked_terminal_buffer_id = last_replaced_buffer_id
     response_sock = vim.fn.sockconnect("pipe", pipe_to_respond_on, {rpc = true})
     unception_quitpre_autocmd_id = vim.api.nvim_create_autocmd("QuitPre",{ command = "lua unception_handle_quitpre(vim.fn.expand('<afile>:p'))"})
 
-    -- Create an autocmd for BufUnload as a failsafe should QuitPre not get triggered on the target buffer (e.g. if a user runs :bdelete)
+    -- Create an autocmd for BufUnload as a failsafe should QuitPre not get triggered on the target buffer (e.g. if a user runs :bdelete).
     unception_bufunload_autocmd_id = vim.api.nvim_create_autocmd("BufUnload",{ command = "lua unception_handle_bufunload(vim.fn.expand('<afile>:p'))"})
 end
 
@@ -72,9 +75,10 @@ function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, 
         vim.cmd("0argadd "..file_args)
 
         if (open_in_new_tab) then
+            last_replaced_buffer_id = nil
             vim.cmd("tab argument 1")
         else
-            id_of_replaced_buffer = vim.fn.bufnr()
+            last_replaced_buffer_id = vim.fn.bufnr()
             vim.cmd("argument 1")
         end
 
@@ -87,15 +91,16 @@ function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, 
         vim.cmd("edit")
     else
         if (open_in_new_tab) then
+            last_replaced_buffer_id = nil
             vim.cmd("tabnew")
         else
-            id_of_replaced_buffer = vim.fn.bufnr()
+            last_replaced_buffer_id = vim.fn.bufnr()
             vim.cmd("enew")
         end
     end
 
-    -- We don't want to delete the replaced buffer if there wasn't a replaced buffer
-    if (delete_replaced_buffer and not open_in_new_tab) then
+    -- We don't want to delete the replaced buffer if there wasn't a replaced buffer.
+    if (delete_replaced_buffer and last_replaced_buffer_id ~= nil) then
         if (vim.fn.len(vim.fn.win_findbuf(tmp_buf_number)) == 0) then
             pcall(vim.cmd, "bdelete! "..tmp_buf_number) -- Use pcall so it doesn't complain if it fails to delete the buffer.
         end

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -10,9 +10,10 @@ function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
     unloaded_buffer_filepath = escape_special_chars(unloaded_buffer_filepath)
 
     if (unloaded_buffer_filepath == filepath_to_check) then
-        local win_id = vim.fn.win_getid()
+        local winnr = vim.fn.winnr()
         vim.cmd("split")
-        vim.cmd(win_id .. "-" .. win_id .. "windo buffer " .. id_of_replaced_buffer)
+        vim.cmd("buffer " .. id_of_replaced_buffer)
+        vim.cmd("wincmd x") -- Navigate to previous window.
 
         vim.api.nvim_del_autocmd(unception_bufunload_autocmd_id)
         vim.fn.rpcnotify(response_sock, "nvim_exec_lua", "vim.cmd('quit')", {})

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -3,12 +3,17 @@ require("common.common_functions")
 local response_sock
 local unception_bufunload_autocmd_id
 local filepath_to_check
+local id_of_replaced_buffer = nil
 
 function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
     unloaded_buffer_filepath = get_absolute_filepath(unloaded_buffer_filepath)
     unloaded_buffer_filepath = escape_special_chars(unloaded_buffer_filepath)
 
     if (unloaded_buffer_filepath == filepath_to_check) then
+        local win_id = vim.fn.win_getid()
+        vim.cmd("split")
+        vim.cmd(win_id .. "-" .. win_id .. "windo buffer " id_of_replaced_buffer)
+
         vim.api.nvim_del_autocmd(unception_bufunload_autocmd_id)
         vim.fn.rpcnotify(response_sock, "nvim_exec_lua", "vim.cmd('quit')", {})
         vim.fn.chanclose(response_sock)
@@ -38,6 +43,7 @@ function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, 
         if (open_in_new_tab) then
             vim.cmd("tab argument 1")
         else
+            id_of_replaced_buffer = vim.fn.bufnr()
             vim.cmd("argument 1")
         end
 
@@ -52,6 +58,7 @@ function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, 
         if (open_in_new_tab) then
             vim.cmd("tabnew")
         else
+            id_of_replaced_buffer = vim.fn.bufnr()
             vim.cmd("enew")
         end
     end

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -10,10 +10,14 @@ function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
     unloaded_buffer_filepath = escape_special_chars(unloaded_buffer_filepath)
 
     if (unloaded_buffer_filepath == filepath_to_check) then
-        local winnr = vim.fn.winnr()
-        vim.cmd("split")
-        vim.cmd("buffer " .. id_of_replaced_buffer)
-        vim.cmd("wincmd x") -- Navigate to previous window.
+        -- If there was a replaced buffer, we should restore it to the same window.
+        if (id_of_replaced_buffer ~= nil) then
+            local winnr = vim.fn.winnr()
+            vim.cmd("split") -- Open a new window and switch focus to it
+            vim.cmd("buffer " .. id_of_replaced_buffer) -- Set the buffer for that window to the buffer that was replaced.
+            vim.cmd("wincmd x") -- Navigate to previous (initial) window.
+            id_of_replaced_buffer = nil
+        end
 
         vim.api.nvim_del_autocmd(unception_bufunload_autocmd_id)
         vim.fn.rpcnotify(response_sock, "nvim_exec_lua", "vim.cmd('quit')", {})

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -41,9 +41,10 @@ function unception_handle_quitpre(quitpre_buffer_filepath)
     if (quitpre_buffer_filepath == filepath_to_check) then
         -- If this buffer replaced the blocked terminal buffer, we should restore it to the same window.
         if (blocked_terminal_buffer_id ~= nil) then
-            vim.cmd("split") -- Open a new window and switch focus to it.
-            vim.cmd("buffer " .. blocked_terminal_buffer_id) -- Set the buffer for that window to the buffer that was replaced.
-            vim.cmd("wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
+            -- Use pcall so that in the case where if the blocked buffer got deleted elsewhere, we won't prevent quitting the buffer.
+            pcall(vim.cmd, "split") -- Open a new window and switch focus to it.
+            pcall(vim.cmd, "buffer " .. blocked_terminal_buffer_id) -- Set the buffer for that window to the buffer that was replaced.
+            pcall(vim.cmd, "wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
         end
 
         unblock_client_and_reset_state()

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -15,7 +15,7 @@ function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
             local winnr = vim.fn.winnr()
             vim.cmd("split") -- Open a new window and switch focus to it
             vim.cmd("buffer " .. id_of_replaced_buffer) -- Set the buffer for that window to the buffer that was replaced.
-            vim.cmd("wincmd x") -- Navigate to previous (initial) window.
+            vim.cmd("wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.
             id_of_replaced_buffer = nil
         end
 

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -12,7 +12,6 @@ function unception_handle_unloaded_buffer(unloaded_buffer_filepath)
     if (unloaded_buffer_filepath == filepath_to_check) then
         -- If there was a replaced buffer, we should restore it to the same window.
         if (id_of_replaced_buffer ~= nil) then
-            local winnr = vim.fn.winnr()
             vim.cmd("split") -- Open a new window and switch focus to it
             vim.cmd("buffer " .. id_of_replaced_buffer) -- Set the buffer for that window to the buffer that was replaced.
             vim.cmd("wincmd x") -- Navigate to previous (initial) window, and proceed with quitting.


### PR DESCRIPTION
If `open_in_new_tab` is set to false, when making a git commit using the `unception_block_while_host_edits` flag, the git commit message buffer will show up in the window of the terminal buffer that was used to run the relevant git command. When the git commit message buffer is quit, the terminal buffer window will be restored. This is more intuitive/consistent with existing functionality for loading in other types of buffers.

Additionally, needing to use `:bdelete` to unload the commit buffer if `'hidden'` is set is no longer necessary. `:q` should now work, since it triggers the `QuitPre` event.

Updated demo video.

TODO:
- [x] Test that having multiple commit message buffers open, and quitting one of them behaves as expected.
- [x] Ensure functionality with terminal toggling plugins is unaffected.
- [x] Come up with solution for situation wherein a user runs a git commit, causing a new commit buffer to replace the terminal window, and then goes on to open a new tab, opens a new terminal buffer, and uses that terminal to open a new file, and then goes back and quits the original git commit message buffer.
- [x] Ensure changes are compatible with Neovim 0.7