### PR TITLE
Verify replaced buffer is a terminal.

### DIFF
--- a/doc/nvim-unception.txt
+++ b/doc/nvim-unception.txt
@@ -40,8 +40,8 @@ SETTINGS                                               *nvim-unception-settings*
         Note: The deleted buffer should always be the terminal buffer that was
     used to launch the new Neovim session, but there are no checks in place
     that mandate that this will always be the case. If the cursor was somehow
-    moved quickly enough to another buffer between the time the client sends
-    the command and the server receives it, this could technically cause
+    moved quickly enough to another terminal buffer between the time the client
+    sends the command and the server receives it, this could technically cause
     deletion of the wrong buffer.
 
 

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -101,8 +101,8 @@ function _G.unception_edit_files(file_args, num_files_in_list, open_in_new_tab, 
 
     -- We don't want to delete the replaced buffer if there wasn't a replaced buffer.
     if (delete_replaced_buffer and last_replaced_buffer_id ~= nil) then
-        if (vim.fn.len(vim.fn.win_findbuf(tmp_buf_number)) == 0) then
-            pcall(vim.cmd, "bdelete! "..tmp_buf_number) -- Use pcall so it doesn't complain if it fails to delete the buffer.
+        if (vim.fn.len(vim.fn.win_findbuf(tmp_buf_number)) == 0 and string.sub(vim.api.nvim_buf_get_name(0), 1, 7) == "term://") then
+            vim.cmd("bdelete! "..tmp_buf_number)
         end
     end
 


### PR DESCRIPTION
Closes #3.

Appears that this may fix #60 as well? I've not been able to reproduce the segfault with this change added. Not sure if the `pcall` had anything to do with it, but I'm fairly sure it's unnecessary in any case.