### PR TITLE
Add support for multiple files, line number, -o -O -p cmd line arguemnt

### DIFF
--- a/lua/client/client.lua
+++ b/lua/client/client.lua
@@ -1,31 +1,30 @@
 require("common.common_functions")
+require("common.arg_parse")
 
 -- We don't want to overwrite :h shada
 vim.o.sdf = "NONE"
 
 -- We don't want to start. Send the args to the server instance instead.
-local args = vim.call("argv")
+-- get only files argument already parsed by neovim
+local true_file_args = vim.call("argv")
 
-local arg_str = ""
-for index, iter in pairs(args) do
-    local absolute_filepath = unception_get_absolute_filepath(iter)
-
-    if (string.len(arg_str) == 0) then
-        arg_str = unception_escape_special_chars(absolute_filepath)
-    else
-        arg_str = arg_str.." "..unception_escape_special_chars(absolute_filepath)
+local options = {}
+-- Use raw argv to retreive some options as well as files lines when it exist
+local guess_argv = extract_args(vim.v.argv, options)
+local file_args = {}
+local true_file_index = 1
+for _, file in ipairs(guess_argv) do
+    -- validate file against true file args
+    if file.path == true_file_args[true_file_index] then
+        local absolute_filepath = unception_get_absolute_filepath(file.path)
+        table.insert(file_args, {path=unception_escape_special_chars(absolute_filepath), line=file.line})
+        true_file_index = true_file_index +1
     end
 end
 
 -- Send messages to host on existing pipe.
 local sock = vim.fn.sockconnect("pipe", os.getenv(unception_pipe_path_host_env_var), {rpc = true})
-local edit_files_call = "unception_edit_files("
-                       .."\""..arg_str.."\", "
-                       ..#args..", "
-                       ..vim.inspect(vim.g.unception_open_buffer_in_new_tab)..", "
-                       ..vim.inspect(vim.g.unception_delete_replaced_buffer)..", "
-                       ..vim.inspect(vim.g.unception_enable_flavor_text)..")"
-vim.fn.rpcrequest(sock, "nvim_exec_lua", edit_files_call, {})
+vim.rpcrequest(sock, "nvim_exec_lua", "unception_edit_files(...)", {file_args, options, vim.g.unception_open_buffer_in_new_tab, vim.g.unception_delete_replaced_buffer, vim.g.unception_enable_flavor_text})
 
 if (not vim.g.unception_block_while_host_edits) then
     -- Our work here is done. Kill the nvim session that would have started otherwise.
@@ -50,10 +49,7 @@ end
 local nested_pipe_path = vim.call("serverstart")
 
 -- Send the pipe path and edited filepath to the host so that it knows what file to look for and who to respond to.
-local notify_when_done_call = "unception_notify_when_done_editing("
-                              ..vim.inspect(nested_pipe_path)..","
-                              ..vim.inspect(arg_str)..")"
-vim.fn.rpcnotify(sock, "nvim_exec_lua", notify_when_done_call, {})
+vim.rpcrequest(sock, "nvim_exec_lua", "unception_notify_when_done_editing(...)", {nested_pipe_path, file_args[1].path})
 
 -- Sleep forever. The host session will kill this when it's done editing.
 while (true)

--- a/lua/client/client.lua
+++ b/lua/client/client.lua
@@ -7,24 +7,26 @@ vim.o.sdf = "NONE"
 -- We don't want to start. Send the args to the server instance instead.
 -- get only files argument already parsed by neovim
 local true_file_args = vim.call("argv")
-
-local options = {}
+local options = {
+    open_in_new_tab = vim.g.unception_open_buffer_in_new_tab,
+    delete_replaced_buffer = vim.g.unception_delete_replaced_buffer,
+    enable_flavor_text = vim.g.unception_enable_flavor_text,
+    multi_file_open_method = vim.g.unception_multi_file_open_method,
+}
 -- Use raw argv to retreive some options as well as files lines when it exist
-local guess_argv = extract_args(vim.v.argv, options)
+local file_lines = unception_arg_parse(vim.v.argv, options)
 local file_args = {}
-local true_file_index = 1
-for _, file in ipairs(guess_argv) do
-    -- validate file against true file args
-    if file.path == true_file_args[true_file_index] then
-        local absolute_filepath = unception_get_absolute_filepath(file.path)
-        table.insert(file_args, {path=unception_escape_special_chars(absolute_filepath), line=file.line})
-        true_file_index = true_file_index +1
-    end
+for _, file in ipairs(true_file_args) do
+    local absolute_filepath = unception_get_absolute_filepath(file)
+    table.insert(file_args , {
+        path = unception_escape_special_chars(absolute_filepath),
+        line = file_lines[file]
+    })
 end
 
 -- Send messages to host on existing pipe.
-local sock = vim.fn.sockconnect("pipe", os.getenv(unception_pipe_path_host_env_var), {rpc = true})
-vim.rpcrequest(sock, "nvim_exec_lua", "unception_edit_files(...)", {file_args, options, vim.g.unception_open_buffer_in_new_tab, vim.g.unception_delete_replaced_buffer, vim.g.unception_enable_flavor_text})
+local sock = vim.fn.sockconnect("pipe", os.getenv(unception_pipe_path_host_env_var), { rpc = true })
+vim.rpcrequest(sock, "nvim_exec_lua", "unception_edit_files(...)", { file_args, options })
 
 if (not vim.g.unception_block_while_host_edits) then
     -- Our work here is done. Kill the nvim session that would have started otherwise.
@@ -49,11 +51,10 @@ end
 local nested_pipe_path = vim.call("serverstart")
 
 -- Send the pipe path and edited filepath to the host so that it knows what file to look for and who to respond to.
-vim.rpcrequest(sock, "nvim_exec_lua", "unception_notify_when_done_editing(...)", {nested_pipe_path, file_args[1].path})
+vim.rpcnotify(sock, "nvim_exec_lua", "unception_notify_when_done_editing(...)", { nested_pipe_path, file_args[1].path })
 
 -- Sleep forever. The host session will kill this when it's done editing.
 while (true)
 do
     vim.cmd("sleep 10")
 end
-

--- a/lua/client/client.lua
+++ b/lua/client/client.lua
@@ -19,7 +19,7 @@ local file_args = {}
 for _, file in ipairs(true_file_args) do
     local absolute_filepath = unception_get_absolute_filepath(file)
     table.insert(file_args , {
-        path = unception_escape_special_chars(absolute_filepath),
+        path = absolute_filepath,
         line = file_lines[file]
     })
 end

--- a/lua/common/arg_parse.lua
+++ b/lua/common/arg_parse.lua
@@ -6,57 +6,138 @@ local function detect_dash_parametes(str)
     return str:match("^-") ~= nil
 end
 
-local dummy_parameters_list = {
+local parameters_map = {
     ["-o"] = "split",
     ["-O"] = "vsplit",
     ["-p"] = "tab",
-    ["--"] = "ignore"
 }
 
 local function detect_parameters(str)
-    local handled_opt = dummy_parameters_list[str]
+    local handled_opt = parameters_map[str]
     if handled_opt then
         return handled_opt
     end
     return detect_dash_parametes(str)
 end
 
-function extract_args(args, options)
-    local files = {}
-    local index = 1
-    for i, arg in ipairs(args) do
-        -- this repeat block allow break to act as continue in the for loop
-        -- it may need some refactoring
-        repeat
-            if i == 1 then
-                break
-            end
-            local opt = detect_parameters(arg)
-            if not options.ignore and opt then
-                if opt ~= true then
-                    options[opt] = true
-                end
-                break
-            end
 
-            local line = detect_line_option(arg)
-            if not options.ignore and line then
-                -- When + option used first let's apply this on the first file
-                local index = (index > 1) and (index - 1) or (index)
-                if not files[index] then
-                    files[index] = {}
-                end
-                files[index].line = line
-                break
-            end
-
-            if not files[index] then
-                files[index] = {}
-            end
-            files[index].path = arg
-            index = index + 1
-            break
-        until false
+local function parse_double_dash(arg, state)
+    if state.double_dash then
+        return false
     end
-    return files
+    if arg == "--" then
+        state.double_dash = true
+        return true
+    end
+    return false
+end
+
+local function parse_option(arg, state)
+    if state.double_dash then
+        return false
+    end
+
+    local opt = detect_parameters(arg)
+
+    if not opt then
+        return false
+    end
+
+    if opt ~= true then
+        state.options.multi_file_open_method = opt
+    end
+    return true
+end
+
+local function parse_line_number(arg, state)
+    if state.double_dash then
+        return false
+    end
+
+    local line = detect_line_option(arg)
+    if not line then
+        return false
+    end
+
+    -- When + option used first let's apply this on the first file
+    local index = (state.index > 1) and (state.index - 1) or (state.index)
+
+    if not state.files[index] then
+        state.files[index] = {}
+    end
+
+    state.files[index].line = line
+
+    return true
+end
+
+local function parse_file(arg, state)
+    if not state.files[state.index] then
+        state.files[state.index] = {}
+    end
+    state.files[state.index].path = arg
+    state.index = state.index + 1
+    return true
+end
+
+---This function filter all files
+---and return only the mapping of files -> line number
+---@param files {[string]:any}[]
+---@return { [string]: integer } dict with file -> line
+local function extract_file_with_line_number(files)
+    local ret = {}
+    for _, file in ipairs(files) do
+        if file.line then
+            ret[file.path] = file.line
+        end
+    end
+
+    return ret
+end
+
+---This is the list of parsing function
+---Note that the order matter
+local parser = {
+    parse_double_dash,
+    parse_option,
+    parse_line_number,
+    parse_file,
+}
+
+---This function parse bare neovim argument list
+---It has two purpose:
+---
+---1. Detect cmd line option `-o -O -p`, and fill the given options
+---2. Detect +\d line number specifier, and returning a dictionary of file:line number
+---Here we don't care of file without any file number since those
+---will be handled by neovim argument parser which is smartest than this parser
+---
+---Limitation: this is a really dumb parser if you run neovim for example with
+---`nvim --cmd "this_is_cmd_argument" +32` this_is_cmd_argument will end up within
+---the list of file returned by this function, we don't really care since files
+---to open will be retrieved by the neovim parser via vim.call("argv") here we want
+---a good enough parser to detect line number after a file and some options that's it
+---@param args string[] this argument need the bare argv from neovim
+---@param options table
+---@return { [string]: integer }
+function unception_arg_parse(args, options)
+    local state = {
+        files = {},
+        index = 1,
+        double_dash = false,
+        options = options
+    }
+
+    -- remove nvim in argv[1]
+    table.remove(args, 1)
+
+    for _, arg in ipairs(args) do
+        for _, fn in ipairs(parser) do
+            if fn(arg, state) then
+                break
+            end
+        end
+    end
+
+   return extract_file_with_line_number(state.files)
 end

--- a/lua/common/arg_parse.lua
+++ b/lua/common/arg_parse.lua
@@ -10,6 +10,7 @@ local parameters_map = {
     ["-o"] = "split",
     ["-O"] = "vsplit",
     ["-p"] = "tab",
+    ["-d"] = "diff",
 }
 
 local function detect_parameters(str)
@@ -66,7 +67,7 @@ local function parse_line_number(arg, state)
         state.files[index] = {}
     end
 
-    state.files[index].line = line
+    state.files[index].line = tonumber(line)
 
     return true
 end

--- a/lua/common/arg_parse.lua
+++ b/lua/common/arg_parse.lua
@@ -7,7 +7,8 @@ local function detect_dash_parametes(str)
 end
 
 local dummy_parameters_list = {
-    ["-O"] = "vplit",
+    ["-o"] = "split",
+    ["-O"] = "vsplit",
     ["-p"] = "tab",
     ["--"] = "ignore"
 }
@@ -24,6 +25,8 @@ function extract_args(args, options)
     local files = {}
     local index = 1
     for i, arg in ipairs(args) do
+        -- this repeat block allow break to act as continue in the for loop
+        -- it may need some refactoring
         repeat
             if i == 1 then
                 break
@@ -50,7 +53,7 @@ function extract_args(args, options)
             if not files[index] then
                 files[index] = {}
             end
-            files[index].file = arg
+            files[index].path = arg
             index = index + 1
             break
         until false

--- a/lua/common/arg_parse.lua
+++ b/lua/common/arg_parse.lua
@@ -1,0 +1,59 @@
+local function detect_line_option(str)
+    return str:match("^%+(%d+)$")
+end
+
+local function detect_dash_parametes(str)
+    return str:match("^-") ~= nil
+end
+
+local dummy_parameters_list = {
+    ["-O"] = "vplit",
+    ["-p"] = "tab",
+    ["--"] = "ignore"
+}
+
+local function detect_parameters(str)
+    local handled_opt = dummy_parameters_list[str]
+    if handled_opt then
+        return handled_opt
+    end
+    return detect_dash_parametes(str)
+end
+
+function extract_args(args, options)
+    local files = {}
+    local index = 1
+    for i, arg in ipairs(args) do
+        repeat
+            if i == 1 then
+                break
+            end
+            local opt = detect_parameters(arg)
+            if not options.ignore and opt then
+                if opt ~= true then
+                    options[opt] = true
+                end
+                break
+            end
+
+            local line = detect_line_option(arg)
+            if not options.ignore and line then
+                -- When + option used first let's apply this on the first file
+                local index = (index > 1) and (index - 1) or (index)
+                if not files[index] then
+                    files[index] = {}
+                end
+                files[index].line = line
+                break
+            end
+
+            if not files[index] then
+                files[index] = {}
+            end
+            files[index].file = arg
+            index = index + 1
+            break
+        until false
+    end
+    return files
+end

--- a/lua/common/common_functions.lua
+++ b/lua/common/common_functions.lua
@@ -39,9 +39,9 @@ function _G.unception_escape_special_chars(str)
         -- filepaths. Lua needs \\ to define a \, so to escape special chars,
         -- there are twice as many backslashes as you would think that there
         -- should be.
-        str = string.gsub(str, "\\", "\\\\\\\\")
-        str = string.gsub(str, "\"", "\\\\\\\"")
-        str = string.gsub(str, " ", "\\\\ ")
+        str = string.gsub(str, "\\", "\\\\")
+        str = string.gsub(str, "\"", "\\\"")
+        str = string.gsub(str, " ", "\\ ")
         return str
     else
         return ""

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -88,6 +88,7 @@ local open_methods_table = {
     vsplit = "vsplit",
     tab = "tabnew",
     argadd = "argadd",
+    diff = "diff",
 }
 
 local function unception_detect_open_method(options)
@@ -95,26 +96,33 @@ local function unception_detect_open_method(options)
     if open_method == nil then
         print("unception can't find multi_file_open_method fall back to tab")
         open_method = "tabnew"
+    elseif open_method == "diff" then
+        -- For now net's assume that the only way to view diff is via vsplit
+        open_method = "vsplit"
+        options.diff = true
     end
     return open_method
 end
 
-local function unception_open_file(open_method, file)
+local function unception_open_file(open_method, file, diff)
     if file.line then
         vim.cmd(("%s +%d %s"):format(open_method, file.line, file.path))
     else
         vim.cmd(("%s %s"):format(open_method, file.path))
+    end
+    if diff then
+        vim.cmd.diffthis()
     end
 end
 
 local function unception_open_file_other(file_args, options, open_method)
     if options.open_in_new_tab and open_method ~= "tabnew" then
         vim.cmd("tabnew")
-        unception_open_file("edit", file_args[1])
+        unception_open_file("edit", file_args[1], options.diff)
         table.remove(file_args, 1)
     end
     for _, file in ipairs(file_args) do
-        unception_open_file(open_method, file)
+        unception_open_file(open_method, file, options.diff)
     end
 end
 

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -136,10 +136,12 @@ function _G.unception_edit_files(file_args, options)
     local open_method = unception_detect_open_method(options)
 
     if (#file_args > 0) then
-        if (open_method == "argadd") then
-            unception_open_file_argadd(file_args, options)
-        else
+        -- if argadd is selected but we have only one file
+        -- let's not use argadd so we can use line number specifier
+        if (open_method ~= "argadd" or #file_args == 1) then
             unception_open_file_other(file_args, options, open_method)
+        else
+            unception_open_file_argadd(file_args, options)
         end
     else
         if (options.open_in_new_tab) then

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -34,7 +34,7 @@ end
 
 function _G.unception_handle_bufunload(unloaded_buffer_filepath)
     unloaded_buffer_filepath = unception_get_absolute_filepath(unloaded_buffer_filepath)
-    unloaded_buffer_filepath = unception_escape_special_chars(unloaded_buffer_filepath)
+    --unloaded_buffer_filepath = unception_escape_special_chars(unloaded_buffer_filepath)
 
     if (unloaded_buffer_filepath == filepath_to_check) then
         unblock_client_and_reset_state()
@@ -43,7 +43,7 @@ end
 
 function _G.unception_handle_quitpre(quitpre_buffer_filepath)
     quitpre_buffer_filepath = unception_get_absolute_filepath(quitpre_buffer_filepath)
-    quitpre_buffer_filepath = unception_escape_special_chars(quitpre_buffer_filepath)
+    --quitpre_buffer_filepath = unception_escape_special_chars(quitpre_buffer_filepath)
 
     if (quitpre_buffer_filepath == filepath_to_check) then
         -- If this buffer replaced the blocked terminal buffer, we should restore it to the same window.
@@ -105,10 +105,11 @@ local function unception_detect_open_method(options)
 end
 
 local function unception_open_file(open_method, file, diff)
+    local path = unception_escape_special_chars(file.path)
     if file.line then
-        vim.cmd(("%s +%d %s"):format(open_method, file.line, file.path))
+        vim.cmd(("%s +%d %s"):format(open_method, file.line, path))
     else
-        vim.cmd(("%s %s"):format(open_method, file.path))
+        vim.cmd(("%s %s"):format(open_method, path))
     end
     if diff then
         vim.cmd.diffthis()
@@ -129,12 +130,12 @@ end
 local function unception_open_file_argadd(file_args, options)
     local path = {}
     for _, file in ipairs(file_args) do
-        table.insert(path, file.path)
+        table.insert(path, unception_escape_special_chars(file.path))
     end
     path = table.concat(path, " ")
     -- Had some issues when using argedit. Explicitly calling these
     -- separately appears to work though.
-    vim.cmd("0argadd "..path)
+    vim.cmd("0argadd " .. path)
 
     if (options.open_in_new_tab) then
         last_replaced_buffer_id = nil

--- a/lua/server/server_functions.lua
+++ b/lua/server/server_functions.lua
@@ -54,6 +54,9 @@ function _G.unception_handle_quitpre(quitpre_buffer_filepath)
         end
 
         unblock_client_and_reset_state()
+        -- this will delete holding buffer, so neovim will be forced
+        -- to reload the file, this fix sequential git rebase -i for example
+        vim.cmd(("bdelete! %d"):format(vim.api.nvim_get_current_buf()))
     end
 end
 
@@ -79,6 +82,9 @@ function _G.unception_notify_when_done_editing(pipe_to_respond_on, filepath)
     -- When done editing in another tab we can't use QuitPre becuase if we switch
     -- back to the previous tabpage within QuitPre it will prevent the tab to be closed
     -- So here we use the TabClosed event
+    if unception_tabclosed_autocmd_id then
+        vim.api.nvim_del_autocmd(unception_tabclosed_autocmd_id)
+    end
     unception_tabclosed_autocmd_id = vim.api.nvim_create_autocmd("TabClosed",
         { callback = unception_handle_tabclosed })
 end

--- a/plugin/main.lua
+++ b/plugin/main.lua
@@ -9,6 +9,11 @@ if(vim.g.unception_open_buffer_in_new_tab == nil) then
     vim.g.unception_open_buffer_in_new_tab = false
 end
 
+-- This is the default opening method, that can be override by cmd line arguement split -o vsplit -O tab -p
+if(vim.g.unception_open_buffer_method_for_other == nil) then
+    vim.g.unception_open_buffer_method_for_other = "tabnew"
+end
+
 if (vim.g.unception_enable_flavor_text == nil) then
     vim.g.unception_enable_flavor_text = true
 end

--- a/plugin/main.lua
+++ b/plugin/main.lua
@@ -15,8 +15,7 @@ if(vim.g.unception_multi_file_open_method == nil) then
     -- split
     -- vplit
     -- argadd
-    --vim.g.unception_multi_file_open_method = "argadd"
-    vim.g.unception_multi_file_open_method = "tab"
+    vim.g.unception_multi_file_open_method = "argadd"
 end
 
 if (vim.g.unception_enable_flavor_text == nil) then

--- a/plugin/main.lua
+++ b/plugin/main.lua
@@ -10,8 +10,13 @@ if(vim.g.unception_open_buffer_in_new_tab == nil) then
 end
 
 -- This is the default opening method, that can be override by cmd line arguement split -o vsplit -O tab -p
-if(vim.g.unception_open_buffer_method_for_other == nil) then
-    vim.g.unception_open_buffer_method_for_other = "tabnew"
+if(vim.g.unception_multi_file_open_method == nil) then
+    -- tab
+    -- split
+    -- vplit
+    -- argadd
+    --vim.g.unception_multi_file_open_method = "argadd"
+    vim.g.unception_multi_file_open_method = "tab"
 end
 
 if (vim.g.unception_enable_flavor_text == nil) then

--- a/plugin/main.lua
+++ b/plugin/main.lua
@@ -1,11 +1,11 @@
 -------------------------------------------------------------------------------
 -- Initialize all expected variables
 -------------------------------------------------------------------------------
-if(vim.g.unception_delete_replaced_buffer == nil) then
+if(vim.g.unception_delete_replaced_buffer == nil or vim.g.unception_delete_replaced_buffer == 0) then
     vim.g.unception_delete_replaced_buffer = false
 end
 
-if(vim.g.unception_open_buffer_in_new_tab == nil) then
+if(vim.g.unception_open_buffer_in_new_tab == nil or vim.g.unception_open_buffer_in_new_tab == 0) then
     vim.g.unception_open_buffer_in_new_tab = false
 end
 
@@ -18,11 +18,11 @@ if(vim.g.unception_multi_file_open_method == nil) then
     vim.g.unception_multi_file_open_method = "argadd"
 end
 
-if (vim.g.unception_enable_flavor_text == nil) then
+if (vim.g.unception_enable_flavor_text == nil or vim.g.unception_enable_flavor_text == 0) then
     vim.g.unception_enable_flavor_text = true
 end
 
-if (vim.g.unception_block_while_host_edits == nil) then
+if (vim.g.unception_block_while_host_edits == nil or vim.g.unception_block_while_host_edits == 0) then
     vim.g.unception_block_while_host_edits = false
 end
 
@@ -31,7 +31,7 @@ if (vim.g.unception_block_while_host_edits) then
     vim.g.unception_delete_replaced_buffer = false
 end
 
-if (vim.g.unception_disable  == nil) then
+if (vim.g.unception_disable == nil or vim.g.unception_disable == 0) then
     vim.g.unception_disable = false
 end
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -1,0 +1,45 @@
+-- really need to find a better solution to include lua file into unit tests
+local function get_source_path()
+    return debug.getinfo(2, "S").source:sub(2):gsub("[a-z-_1-9A-Z]+.lua$", "")
+end
+package.path = package.path .. ";" .. get_source_path() .. "../lua/?.lua"
+require "common.arg_parse"
+
+describe("unception nvim tests", function()
+    describe("argument parser", function()
+        local tests_list = {
+            -- { -- NYI
+            --     intput = { "file", "\\+32" },
+            --     output = { { file = "open" }, { file = "+32" } }
+            -- },
+            {
+                intput = { "/usr/bin/nvim", "file", "+5" },
+                output = { { file = "file", line = "5" } }
+            },
+            {
+                intput = { "/usr/bin/dontcare", "file", "file2", "+32" },
+                output = { { file = "file" }, { file = "file2", line = "32" } }
+            },
+            {
+                intput = { "/usr/bin/dontcare", "--ignored-option-long", "-i", "file", "file2", "+32" },
+                output = { { file = "file" }, { file = "file2", line = "32" } }
+            },
+            -- { -- NYI
+            --     intput = { "/usr/bin/dontcare", "\\- file starting with dash" },
+            --     output = { { file = "- file starting with dash" } }
+            -- },
+            {
+                intput = { "/usr/bin/dontcare", "--", "- file starting with dash" },
+                output = { { file = "- file starting with dash" } }
+            }
+        }
+        for i, test in ipairs(tests_list) do
+            it("argument parser " .. tostring(i), function()
+                local options = {}
+                local ret = extract_args(test.intput, options)
+                assert.are.same(test.output, ret)
+            end)
+        end
+
+    end)
+end)

--- a/test/test.lua
+++ b/test/test.lua
@@ -9,35 +9,50 @@ describe("unception nvim tests", function()
     describe("argument parser", function()
         local tests_list = {
             -- { -- NYI
-            --     intput = { "file", "\\+32" },
+            --     argv = { "file", "\\+32" },
             --     output = { { file = "open" }, { file = "+32" } }
             -- },
             {
-                intput = { "/usr/bin/nvim", "file", "+5" },
-                output = { { file = "file", line = "5" } }
+                argv = { "/usr/bin/nvim", "file", "+5", "-p" },
+                output = { { path = "file", line = "5" } },
+                option = { multi_file_open_method="tab" }
             },
             {
-                intput = { "/usr/bin/dontcare", "file", "file2", "+32" },
-                output = { { file = "file" }, { file = "file2", line = "32" } }
+                argv = { "/usr/bin/dontcare", "file", "file2", "+32" },
+                output = { { path = "file" }, { path = "file2", line = "32" } },
+                option = { }
             },
             {
-                intput = { "/usr/bin/dontcare", "--ignored-option-long", "-i", "file", "file2", "+32" },
-                output = { { file = "file" }, { file = "file2", line = "32" } }
+                argv = { "/usr/bin/dontcare", "--ignored-option-long", "-i", "file", "file2", "+32" },
+                output = { { path = "file" }, { path = "file2", line = "32" } },
+                option = { }
             },
             -- { -- NYI
-            --     intput = { "/usr/bin/dontcare", "\\- file starting with dash" },
+            --     argv = { "/usr/bin/dontcare", "\\- file starting with dash" },
             --     output = { { file = "- file starting with dash" } }
             -- },
             {
-                intput = { "/usr/bin/dontcare", "--", "- file starting with dash" },
-                output = { { file = "- file starting with dash" } }
-            }
+                argv = { "/usr/bin/dontcare", "--", "- file starting with dash" },
+                output = { { path = "- file starting with dash" } },
+                option = { }
+            },
+            {
+                argv = { "/usr/bin/nvim", "file", "+5", "-o" },
+                output = { { path = "file", line = "5" } },
+                option = { multi_file_open_method="split" }
+            },
+            {
+                argv = { "/usr/bin/nvim", "file", "+5", "-O" },
+                output = { { path = "file", line = "5" } },
+                option = { multi_file_open_method="vsplit" }
+            },
         }
         for i, test in ipairs(tests_list) do
             it("argument parser " .. tostring(i), function()
                 local options = {}
-                local ret = extract_args(test.intput, options)
+                local ret = unception_arg_parse(test.argv, options)
                 assert.are.same(test.output, ret)
+                assert.are.same(options, test.option)
             end)
         end
 

--- a/test/unception_arg_parse_test.lua
+++ b/test/unception_arg_parse_test.lua
@@ -8,43 +8,44 @@ require "common.arg_parse"
 describe("unception nvim tests", function()
     describe("argument parser", function()
         local tests_list = {
-            -- { -- NYI
-            --     argv = { "file", "\\+32" },
-            --     output = { { file = "open" }, { file = "+32" } }
-            -- },
             {
                 argv = { "/usr/bin/nvim", "file", "+5", "-p" },
-                output = { { path = "file", line = "5" } },
-                option = { multi_file_open_method="tab" }
+                output = { file = 5 },
+                option = { multi_file_open_method = "tab" }
             },
             {
                 argv = { "/usr/bin/dontcare", "file", "file2", "+32" },
-                output = { { path = "file" }, { path = "file2", line = "32" } },
-                option = { }
+                output = { file2 = 32 },
+                option = {}
             },
             {
-                argv = { "/usr/bin/dontcare", "--ignored-option-long", "-i", "file", "file2", "+32" },
-                output = { { path = "file" }, { path = "file2", line = "32" } },
-                option = { }
+                argv = { "/usr/bin/dontcare", "--ignored-option-long", "-i", "file2", "+32" },
+                output = { file2 = 32 },
+                option = {}
             },
             -- { -- NYI
             --     argv = { "/usr/bin/dontcare", "\\- file starting with dash" },
             --     output = { { file = "- file starting with dash" } }
             -- },
             {
-                argv = { "/usr/bin/dontcare", "--", "- file starting with dash" },
-                output = { { path = "- file starting with dash" } },
-                option = { }
+                argv = { "/usr/bin/dontcare", "+15", "--", "- file starting with dash" },
+                output = { ["- file starting with dash"] = 15 },
+                option = {}
             },
             {
                 argv = { "/usr/bin/nvim", "file", "+5", "-o" },
-                output = { { path = "file", line = "5" } },
-                option = { multi_file_open_method="split" }
+                output = { file = 5 },
+                option = { multi_file_open_method = "split" }
             },
             {
                 argv = { "/usr/bin/nvim", "file", "+5", "-O" },
-                output = { { path = "file", line = "5" } },
-                option = { multi_file_open_method="vsplit" }
+                output = { file = 5 },
+                option = { multi_file_open_method = "vsplit" }
+            },
+            {
+                argv = { "/usr/bin/nvim", "file", "file2", "+3", "-d" },
+                output = { file2 = 3 },
+                option = { multi_file_open_method = "diff" }
             },
         }
         for i, test in ipairs(tests_list) do
@@ -55,6 +56,5 @@ describe("unception nvim tests", function()
                 assert.are.same(options, test.option)
             end)
         end
-
     end)
 end)


### PR DESCRIPTION
In This PR which add some cmd line option parsing capabilities

Added:
- new config g.unception_multi_file_open_method that will control how successive file will be opened (default still argadd)
- cmd line option -o -O -p  is detected to overwrite config `vim.g.unception_multi_file_open_method`
  so for example by default the argadd method is used, so only one file will be visisble
  but if you type `nvim file1 file2 -O` both file will be open in a vsplit
- cmd line option -d is detected this will open all file in a vsplit and mark them for diff using :diffthis
- cmd line option +{number} is detected to open specified file at a given number (this currently doesn't work with argadd method)

Fixed:
- when using --cmd to set global with viml like this `nvim --cmd "let g:unception_disable=0"` now 0 is set to false so lua code handle it properly
  all boolean config value can be set to 0 in viml this will be handled as false

Example usage
```bash
# type this
nvim file1 file2 +2 -o
nvim -d file1 file2 +2
# enjoy
```

What's remaining to do:
- [ ] find better name for unception_multi_file_open_method
- [ ] update the README
- [ ] update doc
- [X] clean up/refacto code + better naming for config and functions
- [ ] add better unit tests
- [X] check potential compatibility issue with vim.fn.rpcrequest vs vim.rpcrequest
  Actualy vim.fn.* will do this lua/viml translation, so it's seems better to use vim.rpcrequest/notify
